### PR TITLE
improve performance

### DIFF
--- a/generators.js
+++ b/generators.js
@@ -82,10 +82,19 @@ exports = module.exports = (function() {
           });
 
         } else {
-          var buf = Buffer(size);
-          var startOffset = getRandomInt(0, pregenBuf.length - (size+1));
-          pregenBuf.copy(buf, 0, startOffset, startOffset + size);
-          return cb.call(this, null, buf);
+          if (false) {
+            // this is safe against downstream consumers writing to the buffer
+            var buf = Buffer(size);
+            var startOffset = getRandomInt(0, pregenBuf.length - (size+1));
+            pregenBuf.copy(buf, 0, startOffset, startOffset + size);
+            return cb.call(this, null, buf);
+          } else {
+            // this is about 7% faster, but is NOT safe against downstream
+            // consumers writing to the buffer
+            var startOffset = getRandomInt(0, pregenBuf.length - (size+1));
+            var buf = pregenBuf.slice(startOffset, startOffset + size);
+            return cb.call(this, null, buf);
+          }
         }
       }
 

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
   "author": "Chakrit Wichian <service@chakrit.net> (http://chakrit.net)",
   "license": "BSD",
   "dependencies": {
-    "readable-stream": "~1.1.0",
+    "readable-stream": "~1.0.x",
     "throttle": "~1.0.3"
   }
 }


### PR DESCRIPTION
I noticed after going from 0.3.1 to 0.3.2, that performance of random and pseudo modes dropped by 50%!  It looks like readable-stream 1.1.0 is to blame.

| mode | 0.3.1 | 0.3.2 | PR |
| --- | --- | --- | --- |
| random | 400Mbps | 197Mbps | 453Mbps |
| pseudo | 382Mbps | 202Mbps | 451Mbps |
| 0 | 845Mbps | 810Mbps | 822Mbps |
| alpha | -- | 263Mbps | 256Mbps |
| num | -- | 244Mbps | 241Mbps |
| pregenerated | -- | 785Mbps | 845Mbps |

I don't know why, and haven't looked around for readable-stream issues that may be related, but just dropping back from 1.1.0 to 1.0.x fixes it.  I also tweaked the pregenerated mode for speed, but it comes at the cost of being vulnerable to downstream consumers writing to the returned data.  For that reason, I left both behaviors in there, with only the faster behavior active.
